### PR TITLE
Prevent incorrect move

### DIFF
--- a/SyncPro.Adapters.WindowsFileSystem/WindowsFileSystemAdapter.cs
+++ b/SyncPro.Adapters.WindowsFileSystem/WindowsFileSystemAdapter.cs
@@ -175,7 +175,8 @@
                 else if (updateInfo.Entry.Type == SyncEntryType.Directory)
                 {
                     Pre.Assert(!string.IsNullOrEmpty(newFullPath), "newFullPath != null");
-                    Directory.Move(fullPath, newFullPath);
+                    if (fullPath != newFullPath)
+                        Directory.Move(fullPath, newFullPath);
                 }
                 else
                 {


### PR DESCRIPTION
Moving from a to b where a=b will caouse system.io.exception => job fails